### PR TITLE
Chat_CRUD & Web Socket Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Web Socket (실시간 채팅) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+
+
         <!-- 스프링 시큐리티 (Spring Security) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/project/securelogin/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/project/securelogin/chat/controller/ChatMessageController.java
@@ -1,4 +1,131 @@
 package com.project.securelogin.chat.controller;
 
+import com.project.securelogin.chat.domain.ChatMessage;
+import com.project.securelogin.chat.dto.ChatMessageDTO;
+import com.project.securelogin.chat.service.ChatMessageService;
+import com.project.securelogin.global.dto.ChatMessageJsonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/messages")
+@RequiredArgsConstructor
 public class ChatMessageController {
+
+    private final ChatMessageService chatMessageService;
+
+    // 메시지 생성
+    @PostMapping
+    public ResponseEntity<ChatMessageJsonResponse> createMessage(
+            @RequestParam Long chatRoomId,
+            @RequestParam Long senderId,
+            @RequestParam String content,
+            @RequestParam String messageType) {
+        ChatMessage chatMessage = chatMessageService.createMessage(chatRoomId, senderId, content, messageType);
+        ChatMessageDTO chatMessageDTO = ChatMessageDTO.from(chatMessage);
+        ChatMessageJsonResponse response = new ChatMessageJsonResponse(
+                HttpStatus.CREATED.value(),
+                "메시지가 성공적으로 생성되었습니다.",
+                chatMessageDTO,
+                null
+        );
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    // 메시지 업데이트
+    @PutMapping("/{messageId}")
+    public ResponseEntity<ChatMessageJsonResponse> updateMessage(
+            @PathVariable Long messageId,
+            @RequestParam String newContent,
+            @RequestParam String newStatus) {
+        ChatMessage updatedMessage = chatMessageService.updateMessage(messageId, newContent, newStatus);
+        ChatMessageDTO chatMessageDTO = ChatMessageDTO.from(updatedMessage);
+        ChatMessageJsonResponse response = new ChatMessageJsonResponse(
+                HttpStatus.OK.value(),
+                "메시지가 성공적으로 업데이트되었습니다.",
+                chatMessageDTO,
+                null
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    // 메시지 중요 표시/해제
+    @PatchMapping("/{messageId}/importance")
+    public ResponseEntity<ChatMessageJsonResponse> toggleMessageImportance(@PathVariable Long messageId) {
+        ChatMessage updatedMessage = chatMessageService.toggleMessageImportance(messageId);
+        ChatMessageDTO chatMessageDTO = ChatMessageDTO.from(updatedMessage);
+        ChatMessageJsonResponse response = new ChatMessageJsonResponse(
+                HttpStatus.NO_CONTENT.value(),
+                "메시지 중요도가 성공적으로 변경되었습니다.",
+                null,
+                null
+        );
+        return ResponseEntity.noContent().build();
+    }
+
+    // 메시지 삭제
+    @DeleteMapping("/{messageId}")
+    public ResponseEntity<ChatMessageJsonResponse> deleteMessage(@PathVariable Long messageId) {
+        chatMessageService.deleteMessage(messageId);
+        ChatMessageJsonResponse response = new ChatMessageJsonResponse(
+                HttpStatus.NO_CONTENT.value(),
+                "메시지가 성공적으로 삭제되었습니다.",
+                null,
+                null
+        );
+        return ResponseEntity.noContent().build();
+    }
+
+    // 파일 URL 첨부
+    @PatchMapping("/{messageId}/file")
+    public ResponseEntity<ChatMessageJsonResponse> attachFileToMessage(
+            @PathVariable Long messageId,
+            @RequestParam String fileUrl) {
+        ChatMessage updatedMessage = chatMessageService.attachFileToMessage(messageId, fileUrl);
+        ChatMessageDTO chatMessageDTO = ChatMessageDTO.from(updatedMessage);
+        ChatMessageJsonResponse response = new ChatMessageJsonResponse(
+                HttpStatus.NO_CONTENT.value(),
+                "파일이 메시지에 성공적으로 첨부되었습니다.",
+                null,
+                null
+        );
+        return ResponseEntity.noContent().build();
+    }
+
+    // 답장 메시지 설정
+    @PatchMapping("/{messageId}/reply")
+    public ResponseEntity<ChatMessageJsonResponse> replyToMessage(
+            @PathVariable Long messageId,
+            @RequestParam Long replyToMessageId) {
+        ChatMessage updatedMessage = chatMessageService.replyToMessage(messageId, replyToMessageId);
+        ChatMessageDTO chatMessageDTO = ChatMessageDTO.from(updatedMessage);
+        ChatMessageJsonResponse response = new ChatMessageJsonResponse(
+                HttpStatus.NO_CONTENT.value(),
+                "답장 메시지가 성공적으로 설정되었습니다.",
+                null,
+                null
+        );
+        return ResponseEntity.noContent().build();
+    }
+
+    // 채팅방의 모든 메시지 조회
+    @GetMapping("/chatroom/{chatRoomId}")
+    public ResponseEntity<ChatMessageJsonResponse> getMessagesByChatRoom(@PathVariable Long chatRoomId) {
+        List<ChatMessage> chatMessages = chatMessageService.getMessagesByChatRoom(chatRoomId);
+        List<ChatMessageDTO> chatMessageDTOs = chatMessages.stream()
+                .map(ChatMessageDTO::from)
+                .collect(Collectors.toList());
+        ChatMessageJsonResponse response = new ChatMessageJsonResponse(
+                HttpStatus.OK.value(),
+                "채팅방의 모든 메시지가 성공적으로 조회되었습니다.",
+                null,
+                chatMessageDTOs
+        );
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/project/securelogin/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/project/securelogin/chat/controller/ChatRoomController.java
@@ -1,4 +1,75 @@
 package com.project.securelogin.chat.controller;
 
+import com.project.securelogin.chat.domain.ChatRoom;
+import com.project.securelogin.chat.dto.ChatRoomDTO;
+import com.project.securelogin.chat.service.ChatRoomService;
+import com.project.securelogin.global.dto.ChatRoomJsonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/chatroom")
+@RequiredArgsConstructor
 public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    // 채팅방 생성
+    @PostMapping
+    public ResponseEntity<ChatRoomJsonResponse> createChatRoom(@RequestParam String chatRoomName) {
+        ChatRoom chatRoom = chatRoomService.createChatRoom(chatRoomName);
+        ChatRoomDTO chatRoomDTO = ChatRoomDTO.from(chatRoom);
+        ChatRoomJsonResponse response = new ChatRoomJsonResponse(HttpStatus.CREATED.value(), "채팅방이 성공적으로 생성되었습니다.", List.of(chatRoomDTO));
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    // 채팅방 이름 업데이트
+    @PutMapping("/{chatRoomId}/name")
+    public ResponseEntity<ChatRoomJsonResponse> updateChatRoomName(@PathVariable Long chatRoomId, @RequestParam String newName) {
+        ChatRoom updatedChatRoom = chatRoomService.updateChatRoomName(chatRoomId, newName);
+        ChatRoomDTO chatRoomDTO = ChatRoomDTO.from(updatedChatRoom);
+        ChatRoomJsonResponse response = new ChatRoomJsonResponse(HttpStatus.OK.value(), "채팅방 이름이 성공적으로 업데이트되었습니다.", List.of(chatRoomDTO));
+        return ResponseEntity.ok(response);
+    }
+
+    // 채팅방에 사용자 추가
+    @PostMapping("/{chatRoomId}/users/{userId}")
+    public ResponseEntity<ChatRoomJsonResponse> addUserToChatRoom(@PathVariable Long chatRoomId, @PathVariable Long userId) {
+        chatRoomService.addUserToChatRoom(chatRoomId, userId);
+        ChatRoomJsonResponse response = new ChatRoomJsonResponse(HttpStatus.NO_CONTENT.value(), "사용자가 채팅방에 성공적으로 추가되었습니다.", null);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 채팅방에서 사용자 제거
+    @DeleteMapping("/{chatRoomId}/users/{userId}")
+    public ResponseEntity<ChatRoomJsonResponse> removeUserFromChatRoom(@PathVariable Long chatRoomId, @PathVariable Long userId) {
+        chatRoomService.removeUserFromChatRoom(chatRoomId, userId);
+        ChatRoomJsonResponse response = new ChatRoomJsonResponse(HttpStatus.NO_CONTENT.value(), "사용자가 채팅방에서 성공적으로 제거되었습니다.", null);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 채팅방 조회
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ChatRoomJsonResponse> getChatRoom(@PathVariable Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
+        ChatRoomDTO chatRoomDTO = ChatRoomDTO.from(chatRoom);
+        ChatRoomJsonResponse response = new ChatRoomJsonResponse(HttpStatus.OK.value(), "채팅방이 성공적으로 조회되었습니다.", List.of(chatRoomDTO));
+        return ResponseEntity.ok(response);
+    }
+
+    // 모든 채팅방 조회
+    @GetMapping
+    public ResponseEntity<ChatRoomJsonResponse> getAllChatRooms() {
+        List<ChatRoom> chatRooms = (List<ChatRoom>) chatRoomService.getAllChatRooms();
+        List<ChatRoomDTO> chatRoomDTOs = chatRooms.stream()
+                .map(ChatRoomDTO::from)
+                .collect(Collectors.toList());
+        ChatRoomJsonResponse response = new ChatRoomJsonResponse(HttpStatus.OK.value(), "모든 채팅방이 성공적으로 조회되었습니다.", chatRoomDTOs);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/project/securelogin/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/com/project/securelogin/chat/dto/ChatMessageDTO.java
@@ -1,0 +1,43 @@
+package com.project.securelogin.chat.dto;
+
+import com.project.securelogin.chat.domain.ChatMessage;
+import com.project.securelogin.user.dto.UserResponseDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatMessageDTO {
+    private Long id;
+    private ChatRoomDTO chatRoom; // 채팅방 정보 포함
+    private UserResponseDTO sender; // 사용자 정보 포함
+    private String content;
+    private LocalDateTime timestamp;
+    private String status;
+    private String messageType;
+    private LocalDateTime editedAt;
+    private ChatMessageDTO replyToMessage; // 답장 메시지 정보
+    private boolean isImportant;
+    private String fileUrl;
+
+    // ChatMessage 엔티티를 ChatMessageDTO로 변환하는 메서드
+    public static ChatMessageDTO from(ChatMessage chatMessage) {
+        return ChatMessageDTO.builder()
+                .id(chatMessage.getId())
+                .chatRoom(ChatRoomDTO.from(chatMessage.getChatRoom()))
+                .sender(UserResponseDTO.from(chatMessage.getSender()))
+                .content(chatMessage.getContent())
+                .timestamp(chatMessage.getTimestamp())
+                .status(chatMessage.getStatus())
+                .messageType(chatMessage.getMessageType())
+                .editedAt(chatMessage.getEditedAt())
+                .replyToMessage(chatMessage.getReplyToMessage() != null
+                        ? from(chatMessage.getReplyToMessage())
+                        : null)
+                .isImportant(chatMessage.isImportant())
+                .fileUrl(chatMessage.getFileUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/project/securelogin/chat/dto/ChatRoomDTO.java
+++ b/src/main/java/com/project/securelogin/chat/dto/ChatRoomDTO.java
@@ -1,0 +1,33 @@
+package com.project.securelogin.chat.dto;
+
+import com.project.securelogin.chat.domain.ChatRoom;
+import com.project.securelogin.user.dto.UserResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomDTO {
+    private Long id;
+    private String chatRoomName;
+    private Set<UserResponseDTO> users; // 사용자 정보를 포함
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // ChatRoom 엔티티를 ChatRoomDTO로 변환하는 메서드
+    public static ChatRoomDTO from(ChatRoom chatRoom) {
+        return new ChatRoomDTO(
+                chatRoom.getId(),
+                chatRoom.getChatRoomName(),
+                chatRoom.getUsers().stream()
+                        .map(UserResponseDTO::from)
+                        .collect(Collectors.toSet()),
+                chatRoom.getCreatedAt(),
+                chatRoom.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/project/securelogin/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/com/project/securelogin/chat/handler/ChatWebSocketHandler.java
@@ -1,0 +1,49 @@
+package com.project.securelogin.chat.handler;
+
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ChatWebSocketHandler extends TextWebSocketHandler {
+
+    // 채팅방과 연결된 세션을 저장하는 맵
+    private final Map<Long, Set<WebSocketSession>> chatRooms = new HashMap<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        // 채팅방 ID를 쿼리 파라미터에서 가져옴
+        String roomIdParam = (String) session.getAttributes().get("roomId");
+        Long roomId = Long.parseLong(roomIdParam);
+
+        chatRooms.computeIfAbsent(roomId, k -> new HashSet<>()).add(session);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        // 모든 채팅방에서 세션 제거
+        for (Set<WebSocketSession> sessions : chatRooms.values()) {
+            sessions.remove(session);
+        }
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        // 메시지를 수신하면 채팅방 ID를 가져와서 해당 채팅방의 모든 세션에 브로드캐스트
+        String payload = message.getPayload();
+        String roomIdParam = (String) session.getAttributes().get("roomId");
+        Long roomId = Long.parseLong(roomIdParam);
+
+        Set<WebSocketSession> sessions = chatRooms.get(roomId);
+        if (sessions != null) {
+            for (WebSocketSession s : sessions) {
+                s.sendMessage(new TextMessage("Room " + roomId + ": " + payload));
+            }
+        }
+    }
+}

--- a/src/main/java/com/project/securelogin/chat/service/ChatMessageService.java
+++ b/src/main/java/com/project/securelogin/chat/service/ChatMessageService.java
@@ -10,6 +10,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -63,7 +65,7 @@ public class ChatMessageService {
     }
 
     // 메시지 중요 표시/해제
-    public void toggleMessageImportance(Long messageId) {
+    public ChatMessage toggleMessageImportance(Long messageId) {
         ChatMessage chatMessage = chatMessageRepository.findById(messageId)
                 .orElseThrow(() -> new IllegalArgumentException("메시지가 존재하지 않습니다."));
 
@@ -75,6 +77,7 @@ public class ChatMessageService {
         }
 
         chatMessageRepository.save(chatMessage);
+        return chatMessage;
     }
 
     // 메시지 삭제
@@ -87,16 +90,17 @@ public class ChatMessageService {
     }
 
     // 파일 URL 첨부
-    public void attachFileToMessage(Long messageId, String fileUrl) {
+    public ChatMessage attachFileToMessage(Long messageId, String fileUrl) {
         ChatMessage chatMessage = chatMessageRepository.findById(messageId)
                 .orElseThrow(() -> new IllegalArgumentException("메시지가 존재하지 않습니다."));
 
         chatMessage.setFileUrl(fileUrl);
         chatMessageRepository.save(chatMessage);
+        return chatMessage;
     }
 
     // 답장 메시지 설정
-    public void replyToMessage(Long messageId, Long replyToMessageId) {
+    public ChatMessage replyToMessage(Long messageId, Long replyToMessageId) {
         ChatMessage chatMessage = chatMessageRepository.findById(messageId)
                 .orElseThrow(() -> new IllegalArgumentException("메시지가 존재하지 않습니다."));
         ChatMessage replyToMessage = chatMessageRepository.findById(replyToMessageId)
@@ -104,5 +108,11 @@ public class ChatMessageService {
 
         chatMessage.setReplyToMessage(replyToMessage);
         chatMessageRepository.save(chatMessage);
+        return chatMessage;
+    }
+
+    // 채팅방의 모든 메시지 조회
+    public List<ChatMessage> getMessagesByChatRoom(Long chatRoomId) {
+        return chatMessageRepository.findByChatRoomId(chatRoomId);
     }
 }

--- a/src/main/java/com/project/securelogin/config/WebSocketConfig.java
+++ b/src/main/java/com/project/securelogin/config/WebSocketConfig.java
@@ -1,0 +1,19 @@
+package com.project.securelogin.config;
+
+import com.project.securelogin.chat.handler.ChatWebSocketHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        // 웹 소켓 핸들러를 /ws/chat 경로로 설정
+        registry.addHandler(new ChatWebSocketHandler(), "/ws/chat")
+                .setAllowedOrigins("*"); // 모든 도메인에서 접근 허용
+    }
+}

--- a/src/main/java/com/project/securelogin/global/dto/ChatMessageJsonResponse.java
+++ b/src/main/java/com/project/securelogin/global/dto/ChatMessageJsonResponse.java
@@ -1,0 +1,28 @@
+package com.project.securelogin.global.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.securelogin.chat.dto.ChatMessageDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatMessageJsonResponse {
+    private final int statusCode;
+    private final String message;
+    private final ChatMessageDTO chatMessage;  // 단일 메시지 응답
+    private final List<ChatMessageDTO> chatMessages;  // 메시지 리스트 응답
+
+    public String toJson() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return "{}";
+        }
+    }
+}

--- a/src/main/java/com/project/securelogin/global/dto/ChatRoomJsonResponse.java
+++ b/src/main/java/com/project/securelogin/global/dto/ChatRoomJsonResponse.java
@@ -1,0 +1,27 @@
+package com.project.securelogin.global.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.securelogin.chat.dto.ChatRoomDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatRoomJsonResponse {
+    private final int statusCode;
+    private final String message;
+    private final List<ChatRoomDTO> chatRooms;
+
+    public String toJson() {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return "{}";
+        }
+    }
+}

--- a/src/main/java/com/project/securelogin/global/dto/UserJsonResponse.java
+++ b/src/main/java/com/project/securelogin/global/dto/UserJsonResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class JsonResponse {
+public class UserJsonResponse {
     private final int statusCode;
     private final String message;
     private UserResponseDTO data;

--- a/src/main/java/com/project/securelogin/global/oauth/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/project/securelogin/global/oauth/handler/OAuth2LoginFailureHandler.java
@@ -1,6 +1,6 @@
 package com.project.securelogin.global.oauth.handler;
 
-import com.project.securelogin.global.dto.JsonResponse;
+import com.project.securelogin.global.dto.UserJsonResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -16,7 +16,7 @@ public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHan
     public void onAuthenticationFailure(HttpServletRequest request,
                                         HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
-        JsonResponse jsonResponse = new JsonResponse(
+        UserJsonResponse userJsonResponse = new UserJsonResponse(
                 HttpServletResponse.SC_UNAUTHORIZED,
                 "로그인 실패",
                 null
@@ -24,6 +24,6 @@ public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHan
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
-        response.getWriter().write(jsonResponse.toString());
+        response.getWriter().write(userJsonResponse.toString());
     }
 }

--- a/src/main/java/com/project/securelogin/global/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/project/securelogin/global/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -3,7 +3,7 @@ package com.project.securelogin.global.oauth.handler;
 import com.project.securelogin.global.oauth.domain.CustomOAuth2User;
 import com.project.securelogin.user.domain.CustomUserDetails;
 import com.project.securelogin.user.domain.User;
-import com.project.securelogin.global.dto.JsonResponse;
+import com.project.securelogin.global.dto.UserJsonResponse;
 import com.project.securelogin.user.dto.UserResponseDTO;
 import com.project.securelogin.global.jwt.JwtTokenProvider;
 import com.project.securelogin.global.oauth.userInfo.OAuth2UserInfo;
@@ -51,15 +51,16 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("Refresh-Token", refreshToken);
 
-        JsonResponse jsonResponse = new JsonResponse(
+        UserResponseDTO userResponseDTO = UserResponseDTO.from(user); // UserResponseDTO로 변환
+        UserJsonResponse userJsonResponse = new UserJsonResponse(
                 HttpServletResponse.SC_OK,
                 "로그인 성공",
-                new UserResponseDTO(customOAuth2User.getName(), customOAuth2User.getEmail())
+                userResponseDTO
         );
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
-        response.getWriter().write(jsonResponse.toJson());
+        response.getWriter().write(userJsonResponse.toJson());
     }
 }

--- a/src/main/java/com/project/securelogin/user/controller/AuthController.java
+++ b/src/main/java/com/project/securelogin/user/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.project.securelogin.user.controller;
 
-import com.project.securelogin.global.dto.JsonResponse;
+import com.project.securelogin.global.dto.UserJsonResponse;
 import com.project.securelogin.global.exception.UserAccountLockedException;
 import com.project.securelogin.global.exception.UserNotEnabledException;
 import com.project.securelogin.user.service.AuthService;
@@ -21,39 +21,39 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<JsonResponse> login(@RequestBody AuthRequest authRequest) {
+    public ResponseEntity<UserJsonResponse> login(@RequestBody AuthRequest authRequest) {
         try {
             HttpHeaders headers = authService.login(authRequest.getEmail(), authRequest.getPassword());
-            JsonResponse response = new JsonResponse(HttpStatus.OK.value(), "로그인에 성공했습니다.", null);
+            UserJsonResponse response = new UserJsonResponse(HttpStatus.OK.value(), "로그인에 성공했습니다.", null);
             return ResponseEntity.ok().headers(headers).body(response);
         } catch (UsernameNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(new JsonResponse(HttpStatus.NOT_FOUND.value(), e.getMessage(), null));
+                    .body(new UserJsonResponse(HttpStatus.NOT_FOUND.value(), e.getMessage(), null));
         } catch (UserNotEnabledException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new JsonResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage(), null));
+                    .body(new UserJsonResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage(), null));
         } catch (UserAccountLockedException e) {
             return ResponseEntity.status(HttpStatus.LOCKED)
-                    .body(new JsonResponse(HttpStatus.LOCKED.value(), e.getMessage(), null));
+                    .body(new UserJsonResponse(HttpStatus.LOCKED.value(), e.getMessage(), null));
         } catch (AuthenticationException e) {
             int remainingAttempts = authService.getRemainingLoginAttempts(authRequest.getEmail());
             String message = "이메일 주소나 비밀번호가 올바르지 않습니다. " +
                     remainingAttempts + "번 더 로그인에 실패하면 계정이 잠길 수 있습니다.";
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new JsonResponse(HttpStatus.UNAUTHORIZED.value(), message, null));
+                    .body(new UserJsonResponse(HttpStatus.UNAUTHORIZED.value(), message, null));
         }
     }
 
 
     @DeleteMapping("/logout")
-    public ResponseEntity<JsonResponse> logout(@RequestHeader(name = "Refresh-Token") String refreshToken) {
+    public ResponseEntity<UserJsonResponse> logout(@RequestHeader(name = "Refresh-Token") String refreshToken) {
         boolean logoutSuccess = authService.logout(refreshToken);
 
         if (logoutSuccess) {
             return ResponseEntity.noContent().build(); // 204 No Content
         } else {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new JsonResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 접근입니다.", null));
+                    .body(new UserJsonResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 접근입니다.", null));
         }
     }
 

--- a/src/main/java/com/project/securelogin/user/controller/UserController.java
+++ b/src/main/java/com/project/securelogin/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.project.securelogin.user.controller;
 
-import com.project.securelogin.global.dto.JsonResponse;
+import com.project.securelogin.global.dto.UserJsonResponse;
 import com.project.securelogin.user.dto.UserRequestDTO;
 import com.project.securelogin.user.dto.UserResponseDTO;
 import com.project.securelogin.user.service.UserService;
@@ -20,61 +20,61 @@ public class UserController {
 
     @PostMapping("/signup")
     // @Valid 어노테이션을 사용해 `SignUpRequest`의 유효성 검사를 활성화, 통과한 경우 서비스 코드 호출
-    public ResponseEntity<JsonResponse> signUp(@Valid @RequestBody UserRequestDTO userRequestDTO) {
+    public ResponseEntity<UserJsonResponse> signUp(@Valid @RequestBody UserRequestDTO userRequestDTO) {
         try {
             UserResponseDTO userResponseDTO = userService.signUp(userRequestDTO);
-            JsonResponse response = new JsonResponse(HttpStatus.CREATED.value(), "회원 가입이 성공적으로 실행되었습니다. 이메일 인증을 완료해주세요.", userResponseDTO);
+            UserJsonResponse response = new UserJsonResponse(HttpStatus.CREATED.value(), "회원 가입이 성공적으로 실행되었습니다. 이메일 인증을 완료해주세요.", userResponseDTO);
             return ResponseEntity.ok().body(response);
         } catch (IllegalStateException | MessagingException e) {
-            JsonResponse errorResponse = new JsonResponse(HttpStatus.BAD_REQUEST.value(), "이미 등록된 이메일입니다.", null);
+            UserJsonResponse errorResponse = new UserJsonResponse(HttpStatus.BAD_REQUEST.value(), "이미 등록된 이메일입니다.", null);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         }
     }
 
     // 회원 정보 조회
     @GetMapping("/{userId}")
-    public ResponseEntity<JsonResponse> getUser(@PathVariable Long userId) {
+    public ResponseEntity<UserJsonResponse> getUser(@PathVariable Long userId) {
         try {
             UserResponseDTO userResponseDTO = userService.getUserById(userId);
-            JsonResponse response = new JsonResponse(HttpStatus.OK.value(), "회원 정보를 성공적으로 조회했습니다.", userResponseDTO);
+            UserJsonResponse response = new UserJsonResponse(HttpStatus.OK.value(), "회원 정보를 성공적으로 조회했습니다.", userResponseDTO);
             return ResponseEntity.ok().body(response);
         } catch (IllegalStateException e) {
-            JsonResponse errorResponse = new JsonResponse(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다.", null);
+            UserJsonResponse errorResponse = new UserJsonResponse(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다.", null);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
         }
     }
 
     // 회원 정보 수정
     @PutMapping("/{userId}")
-    public ResponseEntity<JsonResponse> updateUser(@PathVariable Long userId, @Valid @RequestBody UserRequestDTO userRequestDTO) {
+    public ResponseEntity<UserJsonResponse> updateUser(@PathVariable Long userId, @Valid @RequestBody UserRequestDTO userRequestDTO) {
         try {
             UserResponseDTO userResponseDTO = userService.updateUser(userId, userRequestDTO);
-            JsonResponse response = new JsonResponse(HttpStatus.OK.value(), "회원 정보를 성공적으로 수정했습니다. 이메일 인증을 완료해주세요.", userResponseDTO);
+            UserJsonResponse response = new UserJsonResponse(HttpStatus.OK.value(), "회원 정보를 성공적으로 수정했습니다. 이메일 인증을 완료해주세요.", userResponseDTO);
             return ResponseEntity.ok().body(response);
         } catch (IllegalStateException e) {
-            JsonResponse errorResponse = new JsonResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage(), null);
+            UserJsonResponse errorResponse = new UserJsonResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage(), null);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         }
     }
 
     // 회원 삭제
     @DeleteMapping("/{userId}")
-    public ResponseEntity<JsonResponse> deleteUser(@PathVariable Long userId) {
+    public ResponseEntity<UserJsonResponse> deleteUser(@PathVariable Long userId) {
         try {
             userService.deleteUser(userId);
-            JsonResponse response = new JsonResponse(HttpStatus.NO_CONTENT.value(), "회원 정보를 성공적으로 삭제했습니다.", null);
+            UserJsonResponse response = new UserJsonResponse(HttpStatus.NO_CONTENT.value(), "회원 정보를 성공적으로 삭제했습니다.", null);
             return ResponseEntity.ok().body(response);
         } catch (IllegalStateException e) {
-            JsonResponse errorResponse = new JsonResponse(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다.", null);
+            UserJsonResponse errorResponse = new UserJsonResponse(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다.", null);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
         }
     }
 
     // 이메일 인증
     @GetMapping("/verify/{token}")
-    public ResponseEntity<JsonResponse> verifyEmail(@PathVariable String token) {
+    public ResponseEntity<UserJsonResponse> verifyEmail(@PathVariable String token) {
         UserResponseDTO userResponseDTO = userService.verifyEmail(token);
-        JsonResponse response = new JsonResponse(HttpStatus.OK.value(), "이메일 인증이 완료되었습니다.", userResponseDTO);
+        UserJsonResponse response = new UserJsonResponse(HttpStatus.OK.value(), "이메일 인증이 완료되었습니다.", userResponseDTO);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/project/securelogin/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/project/securelogin/user/dto/UserResponseDTO.java
@@ -1,11 +1,22 @@
 package com.project.securelogin.user.dto;
 
-import lombok.AllArgsConstructor;
+import com.project.securelogin.user.domain.User;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@Builder
 public class UserResponseDTO {
-    private String username;
-    private String email;
+    private final Long id;
+    private final String username;
+    private final String email;
+
+    // User 엔티티를 UserResponseDTO로 변환하는 메서드
+    public static UserResponseDTO from(User user) {
+        return UserResponseDTO.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .build();
+    }
 }

--- a/src/main/java/com/project/securelogin/user/service/UserService.java
+++ b/src/main/java/com/project/securelogin/user/service/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
 
         userRepository.save(user);
 
-        return new UserResponseDTO(user.getUsername(), user.getEmail());
+        return UserResponseDTO.from(user);
     }
 
     // 이메일 검증
@@ -56,13 +56,13 @@ public class UserService {
         User user = findUserByVerificationToken(token);
         user.enableAccount(); // 엔티티 메서드 사용
         userRepository.save(user);
-        return new UserResponseDTO(user.getUsername(), user.getEmail());
+        return UserResponseDTO.from(user);
     }
 
     // 회원 정보 조회
     public UserResponseDTO getUserById(Long userId) {
         User user = findUserById(userId);
-        return new UserResponseDTO(user.getUsername(), user.getEmail());
+        return UserResponseDTO.from(user);
     }
 
     // 회원 정보 수정
@@ -80,7 +80,7 @@ public class UserService {
             }
 
             userRepository.save(user);
-            return new UserResponseDTO(user.getUsername(), user.getEmail());
+            return UserResponseDTO.from(user);
         }).orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다."));
     }
 

--- a/src/test/java/com/project/securelogin/controller/EmailVerificationTest.java
+++ b/src/test/java/com/project/securelogin/controller/EmailVerificationTest.java
@@ -1,6 +1,6 @@
 package com.project.securelogin.controller;
 
-import com.project.securelogin.global.dto.JsonResponse;
+import com.project.securelogin.global.dto.UserJsonResponse;
 import com.project.securelogin.user.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,8 +33,8 @@ public class EmailVerificationTest {
         String verificationUrl = "/user/verify/" + token;
 
         // Mock 객체 설정
-        JsonResponse jsonResponse = new JsonResponse(HttpStatus.OK.value(), "이메일 인증이 완료되었습니다.", null);
-        when(userService.verifyEmail(anyString())).thenReturn(jsonResponse.getData());
+        UserJsonResponse userJsonResponse = new UserJsonResponse(HttpStatus.OK.value(), "이메일 인증이 완료되었습니다.", null);
+        when(userService.verifyEmail(anyString())).thenReturn(userJsonResponse.getData());
 
         // MockMvc를 이용한 요청 및 응답 검증
         mockMvc = MockMvcBuilders.webAppContextSetup(context).build();


### PR DESCRIPTION
## Pull Request 요약

> _**채팅방과 메시지 처리, 웹 소켓 기본 설정**_

채팅 시스템의 기능을 구현하기 위한 백엔드 작업 내역입니다. 주요 변경 사항은 채팅방과 메시지 처리 API, 웹 소켓 설정 및 핸들러 추가입니다.

### 변경 사항

1. **채팅방 API 추가**
   - 채팅방 생성, 조회, 업데이트, 삭제, 사용자 추가 및 제거 기능을 제공하는 컨트롤러 추가
   - `/chatroom` 경로로 API 엔드포인트 설정

2. **채팅 메시지 API 추가**
   - 메시지 생성, 업데이트, 중요 표시/해제, 삭제, 파일 첨부, 답장 설정 기능을 제공하는 컨트롤러 추가
   - `/message` 경로로 API 엔드포인트 설정

3. **웹 소켓 설정 및 핸들러 구현**
   - 실시간 채팅을 위한 웹 소켓 핸들러 및 설정 추가
   - `/ws/chat` 경로로 웹 소켓 핸들러 등록
   - 채팅방 ID에 기반하여 세션 관리 및 메시지 브로드캐스트 기능 구현

4. **DTO 변경**
   - `UserResponseDTO` 및 `ChatMessageJsonResponse` 클래스 등을 수정하여 응답 구조를 변경함

5. **컨트롤러와 DTO 연결**
   - 컨트롤러에서 DTO를 사용하여 클라이언트에 응답을 반환하는 로직 추가

### 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 링크해주세요. 예) Resolves #123 -->
관련 이슈 없음

### 변경된 동작

- **채팅방 API**: 채팅방에 대한 CRUD 작업이 가능하며, 각 작업에 대해 적절한 응답을 반환합니다.
- **채팅 메시지 API**: 메시지의 생성, 수정, 삭제 및 중요도 설정과 파일 첨부, 답장 설정이 가능해졌습니다.
- **웹 소켓**: 실시간으로 채팅방에 메시지를 브로드캐스트하고, 세션 연결 및 해제를 관리합니다.

### 테스트 방법

- **채팅방 API**: Postman을 사용하여 채팅방 생성, 조회, 업데이트, 삭제 등의 API를 테스트했습니다. 모든 API가 예상대로 동작함을 확인했습니다.
- **채팅 메시지 API**: 메시지 생성, 업데이트, 삭제, 중요 표시/해제, 파일 첨부 및 답장 설정을 포함한 다양한 시나리오를 테스트했습니다.
- **웹 소켓**: 웹 소켓 클라이언트를 사용하여 채팅방에 연결하고 메시지를 송수신하여 실시간 채팅 기능이 정상적으로 작동함을 확인했습니다.

### 기타 정보

- **향후 계획**: 사용자 인증 및 권한 관리, 성능 최적화 및 보안 강화를 추가적으로 고려할 예정입니다.
- **문서화**: API 문서와 웹 소켓 사용법을 문서화하여 팀과 공유할 계획입니다.